### PR TITLE
Name resources after the stack. Allow multiple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ is what these scripts and templates solve for you.
 
 ## Configuration
 
-* Create a ``jitsi-user-XXX.yml`` file and set ``jitsi_user``, ``jitsi_password``, 
+* Create a ``jitsi-user-USERNM.yml`` file and set ``jitsi_user``, ``jitsi_password``, 
   ``public_domain``, ``public_port``. If you want set ``letsenc_mail``, the deployment stack
   will auto-generate Let's Encrypt certs. You can set ``letsenc_domain`` then as well (defaults
-  to ``public_domain``).
+  to ``public_domain``). The ``USERNM`` is an identifier for a specific config, as it contains
+  the ``jitsi_user``, I suggest to tie its naming to it.
   You can override ``public_url``, it will otherwise default to ``https://<public_domain>:<public_port>/``.
   Protect this file, as it will contain the ``jitsi_password``.
 
-* If you don't use Let's Encrypt, you need to provide valid SSL certificates in ``cert.crt`` 
-  and ``cert.key`` for https to work. Protect ``cert.key``. If you do use Let's Encrypt, those 
-  files still need to exist, but you can use empty files -- they won't get used.
+* If you don't use Let's Encrypt, you need to provide valid SSL certificates in ``cert-USERNM.crt`` 
+  and ``cert-USERNM.key`` for https to work. Protect ``cert.key``. If you do use Let's Encrypt, you
+  don't need them. Note: I have not yet tested the automatic key generation via Let's Encrypt yet ...
 
 * You need to also define ``image_jitsi``, ``flavor_jitsi``, ``availability_zone`` and ``public``
   (the network from which to allocate public floating IPs from) to match your cloud.

--- a/cleanup-jitsi.sh
+++ b/cleanup-jitsi.sh
@@ -26,18 +26,14 @@ openstack stack delete -y --wait $STACK_NM
 STACK=$(openstack stack list -f value -c "Stack Name" -c "Stack Status")
 if ! [[ "$STACK" == *"$STACK_NM"* ]]; then exit 0; fi
 openstack server list
-for srv in jitsi; do
-  openstack server delete $srv
-done
+openstack server delete $STACK_NM
 STACK=$(openstack stack list -f value -c "Stack Name" -c "Stack Status")
 if ! [[ "$STACK" == *"$STACK_NM"* ]]; then exit 0; fi
 openstack stack delete -y --wait $STACK_NM
 STACK=$(openstack stack list -f value -c "Stack Name" -c "Stack Status")
 openstack stack list
 if ! [[ "$STACK" == *"$STACK_NM"* ]]; then exit 0; fi
-for sg in jitsi; do
-  openstack security group delete $sg
-done
+openstack security group delete $STACK_NM
 openstack stack delete -y --wait $STACK_NM
 echo "Stack should be gone now ..."
 openstack stack list

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -62,6 +62,9 @@ parameters:
     type: number
     default: -1
 
+
+description: Heat stack for Jitsi deployment using docker-jitsi-meet
+
 ##########
 resources:
 
@@ -72,7 +75,7 @@ resources:
   key:
     type: OS::Nova::KeyPair
     properties:
-      name: jitsi_key
+      name: {get_param: "OS::stack_name"}
       save_private_key: true
 
   jitsi_wait_handle:
@@ -212,7 +215,7 @@ resources:
   security_group_jitsi:
     type: OS::Neutron::SecurityGroup
     properties:
-      name: jitsi
+      name: {get_param: "OS::stack_name"}
       rules:
         - remote_ip_prefix: 0.0.0.0/0
           protocol: tcp
@@ -241,11 +244,12 @@ resources:
   net_jitsi:
     type: OS::Neutron::Net
     properties:
-      name: jitsi
+      name: {get_param: "OS::stack_name"}
 
   subnet_jitsi:
     type: OS::Neutron::Subnet
     properties:
+      name: {get_param: "OS::stack_name"}
       network: {get_resource: net_jitsi}
       cidr: 192.168.10.0/24
       # OTC
@@ -263,6 +267,7 @@ resources:
   router:
     type: OS::Neutron::Router
     properties:
+      name: {get_param: "OS::stack_name"}
       external_gateway_info:
         network: {get_param: public}
         # OTC
@@ -281,6 +286,7 @@ resources:
   jitsi_port:
     type: OS::Neutron::Port
     properties:
+      name: {get_param: "OS::stack_name"}
       network_id: {get_resource: net_jitsi}
       fixed_ips:
         - ip_address: 192.168.10.99
@@ -297,7 +303,7 @@ resources:
   jitsi_server:
     type: OS::Nova::Server
     properties:
-      name: jitsi
+      name: {get_param: "OS::stack_name"}
       key_name: {get_resource: key}
       image: {get_param: image_jitsi}
       flavor: {get_param: flavor_jitsi}


### PR DESCRIPTION
Also, the cert files have been renamed to cert-USERNM.{crt,key}.