### PR TITLE
Avoid waiting indefinitely for pipstrap.py.

### DIFF
--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -216,6 +216,10 @@ resources:
                   openssl dhparam -out ~/.jitsi-meet-cfg/web/nginx/dhparams.pem 2048 &
                   git clone https://github.com/jitsi/docker-jitsi-meet
                   cd docker-jitsi-meet
+                  # We can safely ignore hanging pipstrap if we are not using letenc
+                  if test -z "letsenc_mail"; then
+                    sed -i 's/certbot\-auto \-\-noninteractive/timeout 42 certbot-auto --noninteractive/' web/Dockerfile
+                  fi
                   make
                   cp -p docker-compose.yml etherpad.yml jigasi.yml ~
                   cp -p env.example ~/.env


### PR DESCRIPTION
When building the web container in docker, bootstrapping the certbot
does invoke pipstrap to download packages from pypi.
For reasons not yet completely debugged, this hangs in betacloud --
the connection gets established but then never responds to the first
data exchange (TLS handshake).

This is harmless if we inject certs and are not using the certbot to
actually get new certs from letsenc. So in this case, let's just continue
after 42s if the pistrap did not succeed.