### PR TITLE
Replace logo2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ becoming root and using
 ``docker exec -it root_prosody_1 prosodyctl --config /config/prosody.cfg.lua adduser USERNM2@meet.jitsi``
 to deploy another authenticated user that can create rooms.
 
+However, it is not recommended to login to container and do changes -- they are not persistent and
+won't survive a container restart. So rather use the ``jitsi-user-USERNM.yml`` configuration
+to have several users. In my setup, I redeploy the container every night to have fresh state and
+current software.
+
 Refer to the docker-jitsi-meet(https://github.com/jitsi/docker-jitsi-meet/) documentation
 for more info.
 

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -221,9 +221,9 @@ resources:
                   openssl dhparam -out ~/.jitsi-meet-cfg/web/nginx/dhparams.pem 2048 &
                   git clone https://github.com/jitsi/docker-jitsi-meet
                   cd docker-jitsi-meet
-                  # We can safely ignore hanging pipstrap if we are not using letenc
+                  # We can safely ignore hanging pipstrap if we are not using letsenc
                   if test -z "letsenc_mail"; then
-                    sed -i 's/certbot\-auto \-\-noninteractive/timeout 42 certbot-auto --noninteractive/' web/Dockerfile
+                    sed -i 's/\(certbot\-auto \-\-noninteractive.*$\)/timeout 21 \1 || true/' web/Dockerfile
                   fi
                   # Inject icon/watermark
                   if test -r /root/favicon.ico -a $(stat -c %s /root/favicon.ico) -gt 0; then

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -225,6 +225,19 @@ resources:
                   if test -z "letsenc_mail"; then
                     sed -i 's/certbot\-auto \-\-noninteractive/timeout 42 certbot-auto --noninteractive/' web/Dockerfile
                   fi
+                  # Inject icon/watermark
+                  if test -r /root/favicon.ico -a $(stat -c %s /root/favicon.ico) -gt 0; then
+                    mkdir -p web/rootfs/usr/share/jitsi-meet/images
+                    cp -p /root/favicon.ico web/rootfs/usr/share/jitsi-meet/images/favicon.ico
+                    cp -p /root/favicon.ico web/rootfs/usr/share/jitsi-meet/favicon.ico
+                  fi
+                  if test -r /root/watermark.png -a $(stat -c %s /root/watermark.png) -gt 0; then
+                    mkdir -p web/rootfs/usr/share/jitsi-meet/images
+                    cp -p /root/watermark.png web/rootfs/usr/share/jitsi-meet/images/watermark.png
+                  fi
+                  # Copy rootfs after installing packages, so files can be overwritten
+                  sed -i 's@^COPY rootfs@#COPY rootfs@' web/Dockerfile
+                  sed -i "s@^\(.*rm \-rf /tmp/pkg.*$\)@\1\n\nCOPY rootfs/ /@" web/Dockerfile
                   make
                   cp -p docker-compose.yml etherpad.yml jigasi.yml ~
                   cp -p env.example ~/.env
@@ -328,14 +341,6 @@ resources:
                   done
                   # Restart web container to make SSL/height changes effective
                   docker restart root_web_1
-                  # Inject icon/watermark
-                  if test -r /root/favicon.ico -a $(stat -c %s /root/favicon.ico) -gt 0; then
-                    docker cp /root/favicon.ico root_web_1:/usr/share/jitsi-meet/images/favicon.ico
-                    docker cp /root/favicon.ico root_web_1:/usr/share/jitsi-meet/favicon.ico
-                  fi
-                  if test -r /root/watermark.png -a $(stat -c %s /root/watermark.png) -gt 0; then
-                    docker cp /root/watermark.png root_web_1:/usr/share/jitsi-meet/images/watermark.png
-                  fi
                   # Dial-In
                   if test -n "$JIGASI_SIP_URI"; then
                     # Tweak jigasi default room

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -236,7 +236,7 @@ resources:
                     cp -p /root/watermark.png web/rootfs/usr/share/jitsi-meet/images/watermark.png
                   fi
                   # Copy rootfs after installing packages, so files can be overwritten
-                  sed -i 's@^COPY rootfs@#COPY rootfs@' web/Dockerfile
+                  #sed -i 's@^COPY rootfs@#COPY rootfs@' web/Dockerfile
                   sed -i "s@^\(.*rm \-rf /tmp/pkg.*$\)@\1\n\nCOPY rootfs/ /@" web/Dockerfile
                   make
                   cp -p docker-compose.yml etherpad.yml jigasi.yml ~


### PR DESCRIPTION
Build logo/icon into container rather than copying it in afterwards (which is not persistent).
Requires the web container build to succeed, which was previously not the cases for the non-letsenc case. So this was fixed as well, with the side-benefit of having updated packages in the web container.
For injecting the images into the container, we copy over the rootfs twice in the Dockerfile.