### PR TITLE
Feat/allow using public heat notification ep

### DIFF
--- a/create-jitsi.sh
+++ b/create-jitsi.sh
@@ -75,6 +75,14 @@ if test -z "$STATUS"; then
   else
     touch favicon.ico.gz
   fi
+  # Prepare heat replacement
+  OS_CAT=$(openstack catalog list -f json)
+  OS_HEAT_INT=$(echo "$OS_CAT" | jq '.[]|select(.Type=="orchestration")|.Endpoints[]|select(.interface=="internal")|.url' | tr -d '"')
+  OS_HEAT_PUB=$(echo "$OS_CAT" | jq '.[]|select(.Type=="orchestration")|.Endpoints[]|select(.interface=="public")|.url'  | tr -d '"')
+  OS_HEAT_INT=${OS_HEAT_INT%/*}
+  OS_HEAT_PUB=${OS_HEAT_PUB%/*}
+  EXC='!'
+  echo -e "#${EXC}/bin/bash\nsed \"s@$OS_HEAT_INT@$OS_HEAT_PUB@\" -i run.sh" > heat-public-ep.sh
   openstack stack create --timeout 26 -e jitsi-user-$USERNM.yml -t jitsi-stack.yml jitsi-$USERNM
   if test $? != 0; then
     echo "openstack stack create FAILED for $USERNM"

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -683,8 +683,8 @@ resources:
                 template: |
                   #!/bin/bash
                   if test "workaround_heat_internal_ep_broken" = "true"; then bash heat-public-ep.sh; fi
-             permissions: 0755
-             path: /root/heat-adjust.sh
+            permissions: 0755
+            path: /root/heat-adjust.sh
         runcmd:
           - "/root/set_mtu.sh"
           - "mv /tmp/daemon.json /etc/docker/daemon.json"

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -682,7 +682,7 @@ resources:
                   workaround_heat_internal_ep_broken: {get_param: workaround_heat_internal_ep_broken}
                 template: |
                   #!/bin/bash
-                  if test "workaround_heat_internal_ep_broken" = "true"; then bash heat-public-ep.sh; fi
+                  if test "workaround_heat_internal_ep_broken" = "True"; then /root/heat-public-ep.sh; fi
             permissions: 0755
             path: /root/heat-adjust.sh
         runcmd:

--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -221,6 +221,11 @@ parameters:
     type: boolean
     default: true
 
+  # Needs public heat EP tweak
+  workaround_heat_internal_ep_broken:
+    type: boolean
+    default: false
+
 description: Heat stack for Jitsi deployment using docker-jitsi-meet
 
 ##########
@@ -605,9 +610,13 @@ resources:
                     docker restart root_jigasi_1
                   fi
                   # Signal completion
+                  # FIXME: Replace private with public endpoint if needed:w
                   wc_notify --data-binary '{"status": "SUCCESS"}'
             path: /root/run.sh
             permissions: 0700
+          - content: {get_file: heat-public-ep.sh}
+            path: /root/heat-public-ep.sh
+            permissions: 0750
           - content:
               str_replace:
                 params:
@@ -667,6 +676,15 @@ resources:
               fi
             path: /root/set_mtu.sh
             permissions: 0755
+          - content:
+              str_replace:
+                params:
+                  workaround_heat_internal_ep_broken: {get_param: workaround_heat_internal_ep_broken}
+                template: |
+                  #!/bin/bash
+                  if test "workaround_heat_internal_ep_broken" = "true"; then bash heat-public-ep.sh; fi
+             permissions: 0755
+             path: /root/heat-adjust.sh
         runcmd:
           - "/root/set_mtu.sh"
           - "mv /tmp/daemon.json /etc/docker/daemon.json"
@@ -674,6 +692,7 @@ resources:
           - "/root/build-jitsi.sh"
           - "/root/config-env.sh"
           - "sed -i \"/After=/iAfter=docker.service\" /usr/lib/systemd/system/rc-local.service"
+          - "/root/heat-adjust.sh"
           - "/root/run.sh"
         final_message: "The system is finally up, after $UPTIME seconds"
 
@@ -729,9 +748,9 @@ resources:
     properties:
       name: {get_param: "OS::stack_name"}
       # Comment these out if your cloud does not support them
-      value_specs:
-        availability_zone_hints:
-          - {get_param: availability_zone}
+      #value_specs:
+      #  availability_zone_hints:
+      #    - {get_param: availability_zone}
 
   subnet_jitsi:
     type: OS::Neutron::Subnet
@@ -761,9 +780,9 @@ resources:
         # OTC
         # enable_snat: true
       # Comment these out if your cloud does not support them
-      value_specs:
-        availability_zone_hints:
-          - {get_param: availability_zone}
+      #value_specs:
+      #  availability_zone_hints:
+      #    - {get_param: availability_zone}
 
   router_interface:
     type: OS::Neutron::RouterInterface


### PR DESCRIPTION
Internal endpoint for heat notification does not work on some clouds.
Add option to replace it woth public endpoint.