### PR TITLE
Update default to stable-7830.

### DIFF
--- a/jitsi-stack.yml
+++ b/jitsi-stack.yml
@@ -43,7 +43,7 @@ parameters:
 
   jitsi_version:
     type: string
-    default: stable-7648-4
+    default: stable-7830
     #default: master
 
   # Default 0 is autodetect (using the MTU from the default route's NIC)


### PR DESCRIPTION
Trouble is that we build the docker containers with passing just JITSI_RELEASE=stable. This pulls in the packages from the last stable release, which may not be a perfect fit for the git version we just checked out. Occasionally things break, and this is exactly what happened when using Makefile/Dockerfile from stable-7648-x and the stable packages from 7830. Update to avoid the trouble.

In the future, the safest approach is probably either:
* Use stable-xxxx and just grab the containers from the internet instead of building them, so we avoid a possible mismatch. (If we need to build them, find a way we can pull the old software versions that belong to the target stable tag.)
* Use master all the way through (like we used to do for a long time on our SCS VC server.)

Signed-off-by: Kurt Garloff <kurt@garloff.de>